### PR TITLE
fix(apply): subject were not applied

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -165,6 +165,8 @@ sendsync apply -f templates/cool_email/template.json
 
 		activeVersion.HtmlContent = html
 		activeVersion.PlainContent = plain
+		activeVersion.Subject = activeVersionFile.Subject
+		activeVersion.GeneratePlainContent = false
 
 		requestUri := fmt.Sprintf("/v3/templates/%s/versions/%s", targetTemplate.Id, activeVersion.Id)
 		request := sendgrid.GetRequest(apiKey, requestUri, host)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -21,16 +21,15 @@ type Template struct {
 }
 
 type Version struct {
-	Id                   string
+	Id                   string `json:"id"`
 	TemplateId           string `json:"template_id"`
-	Active               int
-	Editor               string
-	Name                 string
+	Active               int    `json:"active"`
+	Name                 string `json:"name"`
 	ThumbnailUrl         string `json:"thumbnail_url"`
 	HtmlContent          string `json:"html_content,omitempty"`
 	PlainContent         string `json:"plain_content,omitempty"`
-	Subject              string
-	GeneratePlainContent bool `json:"generate_plain_content"`
+	Subject              string `json:"subject,omitempty"`
+	GeneratePlainContent bool   `json:"generate_plain_content"`
 }
 
 type templates struct {


### PR DESCRIPTION
The api is case sensistive for the json keys, so we defined all keys annotations in the struct. The api also fails if you try to set the editor key.
