### PR TITLE
fix(templates)!: change json file keys to lowercase on template object

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -14,10 +14,10 @@ var apiKey = os.Getenv("SENDGRID_API_KEY")
 var host = "https://api.sendgrid.com"
 
 type Template struct {
-	Generation string
-	Name       string
-	Id         string
-	Versions   []Version
+	Generation string    `json:"generation"`
+	Name       string    `json:"name"`
+	Id         string    `json:"id"`
+	Versions   []Version `json:"versions"`
 }
 
 type Version struct {


### PR DESCRIPTION
Para mantener consistencia se cambian los keys del object template para que tengan tambien los keys en lowercase...

https://github.com/budacom/sendsync-action/pull/15

closes PLA-63